### PR TITLE
Add diagnostics for slow fs.promises.readFile

### DIFF
--- a/lib/internal/fs/promises.js
+++ b/lib/internal/fs/promises.js
@@ -284,7 +284,12 @@ async function readFileHandle(filehandle, options) {
   if (signal && signal.aborted) {
     throw lazyDOMException('The operation was aborted', 'AbortError');
   }
+
+  process.recordreplay?.log(`ReadFileHandle Start ${filehandle.fd}`);
+
   const statFields = await binding.fstat(filehandle.fd, false, kUsePromises);
+
+  process.recordreplay?.log(`ReadFileHandle StatDone ${filehandle.fd}`);
 
   if (signal && signal.aborted) {
     throw lazyDOMException('The operation was aborted', 'AbortError');
@@ -310,14 +315,22 @@ async function readFileHandle(filehandle, options) {
       throw lazyDOMException('The operation was aborted', 'AbortError');
     }
     const buf = Buffer.alloc(chunkSize);
+
+    process.recordreplay?.log(`ReadFileHandle ReadStart ${filehandle.fd}`);
+
     const { bytesRead, buffer } =
       await read(filehandle, buf, 0, chunkSize, -1);
+
+    process.recordreplay?.log(`ReadFileHandle ReadDone ${filehandle.fd} ${bytesRead}`);
+
     endOfFile = bytesRead === 0;
     if (bytesRead > 0)
       ArrayPrototypePush(chunks, buffer.slice(0, bytesRead));
   } while (!endOfFile);
 
   const result = Buffer.concat(chunks);
+
+  process.recordreplay?.log(`ReadFileHandle Done ${filehandle.fd}`);
 
   return options.encoding ? result.toString(options.encoding) : result;
 }
@@ -677,8 +690,17 @@ async function readFile(path, options) {
   if (path instanceof FileHandle)
     return readFileHandle(path, options);
 
+  process.recordreplay?.log(`ReadFile Start ${path}`);
+
   const fd = await open(path, flag, 0o666);
-  return PromisePrototypeFinally(readFileHandle(fd, options), fd.close);
+
+  process.recordreplay?.log(`ReadFile Opened ${path} ${fd ? fd.fd : null}`);
+
+  const rv = await PromisePrototypeFinally(readFileHandle(fd, options), fd.close);
+
+  process.recordreplay?.log(`ReadFile Done ${path}`);
+
+  return rv;
 }
 
 module.exports = {


### PR DESCRIPTION
For https://github.com/RecordReplay/backend/issues/5397