### PR TITLE
Fix frame iteration in record/replay methods

### DIFF
--- a/deps/v8/src/debug/debug.cc
+++ b/deps/v8/src/debug/debug.cc
@@ -3212,10 +3212,7 @@ static Handle<Object> RecordReplayCountStackFrames(Isolate* isolate,
   // exception unwinds and so forth.
   size_t count = 0;
   for (JavaScriptFrameIterator it(isolate); !it.done(); it.Advance()) {
-    JavaScriptFrame* frame = JavaScriptFrame::cast(it.frame());
-    if (frame->type() != StackFrame::OPTIMIZED && frame->type() != StackFrame::INTERPRETED) {
-      continue;
-    }
+    JavaScriptFrame* frame = it.frame();
     std::vector<FrameSummary> frames;
     frame->Summarize(&frames);
 
@@ -3285,10 +3282,7 @@ static Handle<Object> RecordReplayCurrentGeneratorId(Isolate* isolate, Handle<Ob
 static Handle<Object> RecordReplayGetStackFunctionIds(Isolate* isolate, Handle<Object> params) {
   std::vector<std::string> functions;
   for (JavaScriptFrameIterator it(isolate); !it.done(); it.Advance()) {
-    JavaScriptFrame* frame = JavaScriptFrame::cast(it.frame());
-    if (frame->type() != StackFrame::OPTIMIZED && frame->type() != StackFrame::INTERPRETED) {
-      continue;
-    }
+    JavaScriptFrame* frame = it.frame();
     std::vector<FrameSummary> frames;
     frame->Summarize(&frames);
 

--- a/deps/v8/src/runtime/runtime-debug.cc
+++ b/deps/v8/src/runtime/runtime-debug.cc
@@ -1047,10 +1047,7 @@ static std::string GetStackContents(Isolate* isolate, size_t max_frames) {
 
   std::string contents;
   for (JavaScriptFrameIterator it(isolate); !it.done(); it.Advance()) {
-    JavaScriptFrame* frame = JavaScriptFrame::cast(it.frame());
-    if (frame->type() != StackFrame::OPTIMIZED && frame->type() != StackFrame::INTERPRETED) {
-      continue;
-    }
+    JavaScriptFrame* frame = it.frame();
     std::vector<FrameSummary> frames;
     frame->Summarize(&frames);
     for (int i = frames.size() - 1; i >= 0; i--) {


### PR DESCRIPTION
Fixes https://github.com/RecordReplay/backend/issues/5803, hopefully.  After the rebase there is a new type of interpreted frame (baseline frames are distinguished from interpreter and optimized frames) but the methods we use to get the stack contents when recording/replaying aren't handling this, leading to instrumentation stacks going out of sync.