### PR TITLE
Fix Target.getSourceMapURL for non-file URLs

### DIFF
--- a/lib/internal/recordreplay/sourcemap.js
+++ b/lib/internal/recordreplay/sourcemap.js
@@ -26,12 +26,12 @@ async function registerSourceMap(ev) {
     log("Failed to process sourcemap url: " + err.message);
     return;
   }
-  if (!sourceMapURL.startsWith("file://")) {
-    return;
-  }
 
   sourceMapURLs.set(ev.scriptId, sourceMapURL);
 
+  if (!sourceMapURL.startsWith("file://")) {
+    return;
+  }
   const sourceMapPath = fileURLToPath(sourceMapURL);
   let sourceMap;
   try {


### PR DESCRIPTION
Necessary for the `data:` URLs of embedded sourcemaps.
Fixes [RUN-416](https://linear.app/replay/issue/RUN-416) 