### PR TITLE
Switch to node 20 on CI

### DIFF
--- a/.github/actions/build-test-branch/action.yml
+++ b/.github/actions/build-test-branch/action.yml
@@ -2,5 +2,5 @@ name: "Build/Test"
 description: "Trigger build/test run"
 
 runs:
-  using: "node12"
+  using: "node20"
   main: "./main.js"

--- a/.github/actions/build-test/action.yml
+++ b/.github/actions/build-test/action.yml
@@ -2,5 +2,5 @@ name: "Build/Test"
 description: "Trigger build/test run"
 
 runs:
-  using: "node12"
+  using: "node20"
   main: "./main.js"

--- a/.github/actions/release/action.yml
+++ b/.github/actions/release/action.yml
@@ -2,5 +2,5 @@ name: "Release"
 description: "Trigger browser release"
 
 runs:
-  using: "node12"
+  using: "node20"
   main: "./main.js"


### PR DESCRIPTION
This has not been touched for a while but I think node12 containers might no longer be available on GitHub Actions. Node 18 is hitting its EOL in 2 days so I switched those configs to use node20