### PR TITLE
Align Node V8 progress handling with Chromium

### DIFF
--- a/deps/v8/src/api/api.cc
+++ b/deps/v8/src/api/api.cc
@@ -10494,6 +10494,14 @@ void RecordReplaySetTargetProgress(uint64_t progress) {
 }
 
 void RecordReplayOnTargetProgressReached() {
+  CHECK(IsMainThread());
+  if (recordreplay::AreEventsDisallowed()) {
+    // We should not have progress updates when events disallowed.
+    if (!recordreplay::HasDivergedFromRecording()) {
+      recordreplay::Warning("OnProgressReached PC=%zu", (size_t)*gProgressCounter);
+    }
+    return;
+  }
   gRecordReplayProgressReached();
 }
 

--- a/deps/v8/src/baseline/baseline-compiler.cc
+++ b/deps/v8/src/baseline/baseline-compiler.cc
@@ -2227,10 +2227,13 @@ void BaselineCompiler::VisitIncBlockCounter() {
 }
 
 void BaselineCompiler::VisitRecordReplayIncExecutionProgressCounter() {
-  if (gRecordReplayAssertProgress) {
+  // The optimized path is currently disabled.
+  // See https://linear.app/replay/issue/RUN-744
+  if ((true)/*gRecordReplayAssertProgress*/) {
     CallRuntime(Runtime::kRecordReplayAssertExecutionProgress,
                 __ FunctionOperand());
   } else {
+    /*
     BaselineAssembler::ScratchRegisterScope scratch_scope(&basm_);
     Register reg1 = scratch_scope.AcquireScratch();
     Register reg2 = scratch_scope.AcquireScratch();
@@ -2244,6 +2247,7 @@ void BaselineCompiler::VisitRecordReplayIncExecutionProgressCounter() {
     __ JumpIfCondition(Condition::kNotEqual, &done, Label::kNear);
     CallRuntime(Runtime::kRecordReplayTargetProgressReached);
     __ Bind(&done);
+    */
   }
 }
 


### PR DESCRIPTION
Note: there is no crash report associated with this. It's just a reported progress mismatch + inconsistent data between basic and scan data that leads to a backend assert in `ensureFramePoint`/`getPointStack`. With inconsistent data, our machinery fails to narrow down the enclosing frame points for a bookmark point.

We've observed progress mismatches. In the recording `af25ba61-465b-4ccb-91ef-183926364d7d` the mismatch goes away when starting the scan later, see the manifest diff (lower `startProgress` mismatches when the higher one stops to mismatch):
```diff
{
  "kind": "scanRecording",
  "endpoint": { "checkpoint": 469, "progress": 2030423 },
-  "startProgress": 2027916,
+  "startProgress": 2027917,
  "getGenerators": true,
  "getDependencies": true,
  "writeScanDataFile": true
}
```

The lower one includes the tail of some Playwright async frame, the higher one "skips" over it. 

It's unclear what the root cause actually is. But I found some optimization-related divergences around progress tracking when comparing things to the current Chromium source code. I think it's worth aligning to the more heavily used and tested Chromium code either way and there is a real chance this will address the issue we have found.

Chromium commits effectively cherry-picked/mirrored:

- [`6183d3132d7f`](https://github.com/replayio/chromium-v8/commit/6183d3132d7f07a3ef6de501e8d7195cbb1e59e6) - Add env var to assert on JS progress changes ([#68](https://github.com/replayio/chromium-v8/pull/68))
- [`3104d7cad00f`](https://github.com/replayio/chromium-v8/commit/3104d7cad00f01771399523a7ae5fdcedf10410b) - Fix build breaks
- [`2055467196a`](https://github.com/replayio/chromium-v8/commit/2055467196a42ee9a05a81cf53ae3a19c8cf2cde) - RUN-2232: Make OnProgressReached a no-op when events disallowed ([#166](https://github.com/replayio/chromium-v8/pull/166))

Related context, but not newly cherry-picked:

- [`4349d6d17f42`](https://github.com/replayio/chromium-v8/commit/4349d6d17f42) - introduced Chromium's optimized counter path; Node already had its own equivalent.
- [`a7cb52b8c2e1`](https://github.com/replayio/chromium-v8/commit/a7cb52b8c2e1) - introduced Chromium's direct progress-reached callback; Node already had the direct callback path.

relates to: https://hub.replay.io/issues/issue/DEBU-6